### PR TITLE
(engine): Add a Result type alias, refactor print_fortivo_error()

### DIFF
--- a/engine/src/error.rs
+++ b/engine/src/error.rs
@@ -1,6 +1,9 @@
 use std::error::Error;
 use thiserror::Error;
 
+/// Type alias for errors in this crate
+type Result<T> = std::result::Result<T, FortivoError>;
+
 /// The main error type used by this crate, it implements the [`std::error::Error`] trait
 #[derive(Error, Debug)]
 pub enum FortivoError {
@@ -8,10 +11,13 @@ pub enum FortivoError {
 	IOError(#[from] std::io::Error)
 }
 
-pub(crate) fn print_fortivo_error(err: &FortivoError) {
-	eprintln!("{}", err);
+impl FortivoError {
+	/// Print this error, and its cause if a source exists
+	pub fn print_error(&self) {
+		eprintln!("{}", self);
 
-	if let Some(source) = err.source() {
-		eprintln!("Caused by: {}", source);
+		if let Some(source) = self.source() {
+			eprintln!("Caused by: {}", source);
+		}
 	}
 }


### PR DESCRIPTION
- Add a specific Result type alias, which Err variant is a FortivoError enum
- Refactor the print_fortivo_error() function into print_error() method
- Add documentation comments for both