### PR TITLE
rft(engine::error): Remove print chain function

### DIFF
--- a/engine/src/error.rs
+++ b/engine/src/error.rs
@@ -1,4 +1,3 @@
-use std::error::Error;
 use thiserror::Error;
 
 /// Type alias for errors in this crate
@@ -9,15 +8,4 @@ type Result<T> = std::result::Result<T, FortivoError>;
 pub enum FortivoError {
 	#[error("An IO error has ocurred")]
 	IOError(#[from] std::io::Error)
-}
-
-impl FortivoError {
-	/// Print this error, and its cause if a source exists
-	pub fn print_error(&self) {
-		eprintln!("{}", self);
-
-		if let Some(source) = self.source() {
-			eprintln!("Caused by: {}", source);
-		}
-	}
 }


### PR DESCRIPTION
Remove FortivoError's method to print the error chain, leave this logic for the end library consumer

Thx to [@glomdom](https://github.com/glomdom) for pointing this out