### PR TITLE
(engine): New "fs" module

### DIFF
--- a/engine/src/fs.rs
+++ b/engine/src/fs.rs
@@ -1,0 +1,22 @@
+use std::{fs::{self, File}, path::Path};
+use crate::error::FortivoResult;
+
+pub struct Arca {
+	handle: File,
+	is_dirty: bool
+}
+
+pub fn new_arca<P: AsRef<Path>>(pathname: P) -> FortivoResult<Arca> {
+	Ok(
+		Arca {
+			handle: File::create_new(pathname)?,
+			is_dirty: false
+		}
+	)
+}
+
+pub fn delete_arca<P: AsRef<Path>>(pathname: P) -> FortivoResult<()> {
+	Ok(
+		fs::remove_file(pathname)?
+	)
+}

--- a/engine/src/fs.rs
+++ b/engine/src/fs.rs
@@ -1,8 +1,9 @@
-use std::{fs::{self, File}, path::Path};
+use std::{fs::{self, File}, path::{Path, PathBuf}};
 use crate::error::FortivoResult;
 
 pub struct Arca {
 	handle: File,
+	path: PathBuf,
 	is_dirty: bool
 }
 
@@ -10,13 +11,14 @@ pub fn new_arca<P: AsRef<Path>>(pathname: P) -> FortivoResult<Arca> {
 	Ok(
 		Arca {
 			handle: File::create_new(pathname)?,
+			path: pathname.as_ref().to_path_buf(),
 			is_dirty: false
 		}
 	)
 }
 
-pub fn delete_arca<P: AsRef<Path>>(pathname: P) -> FortivoResult<()> {
+pub fn delete_arca(arca: Arca) -> FortivoResult<()> {
 	Ok(
-		fs::remove_file(pathname)?
+		fs::remove_file(arca.path)?
 	)
 }


### PR DESCRIPTION
This PR adds a new public module called "fs", the purpose of this module is to provide convenient functions to create and delete Arcas:

- New Arca type, descriptor of an open Arca
- New new_arca() function, creates a new Arca instance 
- New delete_arca() function, takes an Arca instance, deletes its underlying file in the file system and drops the taken instance

Closes #1 