### PR TITLE
(engine): "fs" module and other minor changes

### DIFF
--- a/engine/src/error.rs
+++ b/engine/src/error.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
 
 /// Type alias for errors in this crate
-type Result<T> = std::result::Result<T, FortivoError>;
+pub type FortivoResult<T> = Result<T, FortivoError>;
 
 /// The main error type used by this crate, it implements the [`std::error::Error`] trait
 #[derive(Error, Debug)]

--- a/engine/src/fs.rs
+++ b/engine/src/fs.rs
@@ -1,0 +1,24 @@
+use std::{fs::{self, File}, path::{Path, PathBuf}};
+use crate::error::FortivoResult;
+
+pub struct Arca {
+	handle: File,
+	path: PathBuf,
+	is_dirty: bool
+}
+
+pub fn new_arca<P: AsRef<Path>>(pathname: P) -> FortivoResult<Arca> {
+	Ok(
+		Arca {
+			handle: File::create_new(pathname)?,
+			path: pathname.as_ref().to_path_buf(),
+			is_dirty: false
+		}
+	)
+}
+
+pub fn delete_arca(arca: Arca) -> FortivoResult<()> {
+	Ok(
+		fs::remove_file(arca.path)?
+	)
+}

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -3,6 +3,6 @@
 
 // Public modules
 pub mod error;
+pub mod fs;
 
 // Private modules
-mod fs;


### PR DESCRIPTION
Changes:

- New "fs" module, for details refer to PR #8 
- Make specialized Result type alias public, rename it to FortivoResult
- Make the "fs" module public