### PR TITLE
(engine): new Serdeable trait

### DIFF
--- a/engine/src/fs.rs
+++ b/engine/src/fs.rs
@@ -46,3 +46,11 @@ impl Arca {
 		self.is_dirty
 	}
 }
+
+pub struct ArcaHeader {
+
+}
+
+pub struct Arcanum {
+
+}

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -4,5 +4,6 @@
 // Public modules
 pub mod error;
 pub mod fs;
+pub mod serde;
 
 // Private modules

--- a/engine/src/serde.rs
+++ b/engine/src/serde.rs
@@ -1,0 +1,26 @@
+use crate::{error::FortivoResult, fs::{ArcaHeader, Arcanum}};
+
+trait Serdeable: Sized {
+	fn serialize(&self) -> FortivoResult<&[u8]>;
+	fn deserialize(src: &[u8]) -> FortivoResult<Self>;
+}
+
+impl Serdeable for ArcaHeader {
+	fn serialize(&self) -> FortivoResult<&[u8]> {
+		todo!()
+	}
+
+	fn deserialize(src: &[u8]) -> FortivoResult<Self> {
+		todo!()
+	}
+}
+
+impl Serdeable for Arcanum {
+	fn serialize(&self) -> FortivoResult<&[u8]> {
+		todo!()
+	}
+
+	fn deserialize(src: &[u8]) -> FortivoResult<Self> {
+		todo!()
+	}
+}


### PR DESCRIPTION
This PR adds a new trait, "Serdeable", it defines structs within this engine that could be serialized or deserialized, this will be useful since different structs used by the engine like a possible ArcaHeader or Arcanum can be converted into a byte sequence ready to be written or take as input this byte sequence produced by the std::io::Read trait and output the struct itself

Things added:
TODO

Closes #13 