### PR TITLE
(engine): Logging support via optional feature

### DIFF
--- a/libfortivo/Cargo.toml
+++ b/libfortivo/Cargo.toml
@@ -3,7 +3,10 @@ name = "libfortivo"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+logging = ["dep:log"]
+
 [dependencies]
 serde = { version = "1.0.219", features = ["derive"] }
 thiserror = "2.0.12"
-log = "0.4.28"
+log = { version = "0.4.28", optional = true }

--- a/libfortivo/Cargo.toml
+++ b/libfortivo/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2024"
 [dependencies]
 serde = { version = "1.0.219", features = ["derive"] }
 thiserror = "2.0.12"
+log = "0.4.28"

--- a/libfortivo/src/arca.rs
+++ b/libfortivo/src/arca.rs
@@ -1,7 +1,6 @@
 use std::{fs::File, io::{Seek, SeekFrom}, path::Path, time::{SystemTime, UNIX_EPOCH}};
-use crate::{error::{ArcaHeaderError, FortivoError, FortivoResult}, serde::{deserializer::ArcaHeaderDeserializer, serializer::ArcaHeaderSerializer}};
 use serde::{Deserialize, Serialize};
-use log::{debug, trace};
+use crate::{error::{ArcaHeaderError, FortivoError, FortivoResult}, features::logging::{conditional_debug, conditional_trace}, serde::{deserializer::ArcaHeaderDeserializer, serializer::ArcaHeaderSerializer}};
 
 pub const ALLOWED_FLAGS: u16 = 0b0000_0000_0000_0000;
 pub const ENGINE_VERSION: [u64; 3] = [0, 1, 0];
@@ -14,12 +13,12 @@ pub struct Arca {
 impl Arca {
     pub fn new<P: AsRef<Path>>(path: P, name: &[u8], flags: u16) -> FortivoResult<Self> {
         let file_handle = File::create_new(path.as_ref())?;
-        trace!("Created file handle for new potential Arca");
+        conditional_trace!("Created file handle for new potential Arca");
 
         let arca_header = ArcaHeader::new(name, flags)?;
-        trace!("Created new Arca header for new potential Arca");
+        conditional_trace!("Created new Arca header for new potential Arca");
 
-        debug!("Created a new Arca instance!");
+        conditional_debug!("Created a new Arca instance!");
 
         Ok(
             Self {
@@ -31,15 +30,15 @@ impl Arca {
 
     pub fn open<P: AsRef<Path>>(path: P) -> FortivoResult<Self> {
         let file_handle = File::options().read(true).write(true).open(path.as_ref())?;
-        trace!("Created file handle for new potential Arca");
+        conditional_trace!("Created file handle for new potential Arca");
 
         let arca_header = ArcaHeader::deserialize(ArcaHeaderDeserializer { reader: &file_handle })?;
-        trace!("Deserialized Arca header from existing Arca in filesystem, validating...");
+        conditional_trace!("Deserialized Arca header from existing Arca in filesystem, validating...");
 
         arca_header.validate()?;
-        trace!("Validated deserialized Arca header");
+        conditional_trace!("Validated deserialized Arca header");
 
-        debug!("Created a new Arca instance!");
+        conditional_debug!("Created a new Arca instance!");
 
         Ok(
             Self {
@@ -51,12 +50,12 @@ impl Arca {
 
     pub fn sync(&mut self) -> FortivoResult<()> {
         self.handle.seek(SeekFrom::Start(0))?;
-        trace!("Seeking file handle to start");
+        conditional_trace!("Seeking file handle to start");
 
         self.header.serialize(ArcaHeaderSerializer { writer: &self.handle })?;
-        trace!("Writing the Arca header to filesystem");
+        conditional_trace!("Writing the Arca header to filesystem");
 
-        debug!("Synced Arca instance to filesystem");
+        conditional_debug!("Synced Arca instance to filesystem");
 
         Ok(())
     }
@@ -77,10 +76,10 @@ struct ArcaHeader {
 impl ArcaHeader {
     fn new(name: &[u8], flags: u16) -> FortivoResult<Self> {
         let name_length = name.len();
-        trace!("Getting provided name length...");
+        conditional_trace!("Getting provided name length...");
 
         let current_time = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
-        trace!("Getting current system time...");
+        conditional_trace!("Getting current system time...");
 
         if name_length > 512 {
             return Err(FortivoError::from(ArcaHeaderError::NameTooLong))

--- a/libfortivo/src/features/logging/mod.rs
+++ b/libfortivo/src/features/logging/mod.rs
@@ -1,0 +1,21 @@
+#[cfg(feature = "logging")]
+macro_rules! conditional_debug {
+	($($arg:tt)*) => { log::debug!($($arg)*) }
+}
+
+#[cfg(not(feature = "logging"))]
+macro_rules! conditional_debug {
+	($($arg:tt)*) => {}
+}
+
+#[cfg(feature = "logging")]
+macro_rules! conditional_trace {
+	($($arg:tt)*) => { log::trace!($($arg)*) }
+}
+
+#[cfg(not(feature = "logging"))]
+macro_rules! conditional_trace {
+	($($arg:tt)*) => {}
+}
+
+pub(crate) use {conditional_debug, conditional_trace};

--- a/libfortivo/src/features/mod.rs
+++ b/libfortivo/src/features/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod logging;

--- a/libfortivo/src/lib.rs
+++ b/libfortivo/src/lib.rs
@@ -4,3 +4,4 @@ pub mod arca;
 pub mod error;
 
 pub(crate) mod serde;
+pub(crate) mod features;

--- a/libfortivo/src/lib.rs
+++ b/libfortivo/src/lib.rs
@@ -3,4 +3,4 @@
 pub mod arca;
 pub mod error;
 
-mod serde;
+pub(crate) mod serde;

--- a/libfortivo/src/serde/mod.rs
+++ b/libfortivo/src/serde/mod.rs
@@ -1,2 +1,2 @@
 pub(crate) mod deserializer;
-mod serializer;
+pub(crate) mod serializer;

--- a/libfortivo/src/serde/serializer.rs
+++ b/libfortivo/src/serde/serializer.rs
@@ -2,8 +2,8 @@ use std::io::Write;
 use serde::{ser::Impossible, Serialize, Serializer};
 use crate::error::FortivoError;
 
-struct ArcaHeaderSerializer<W: Write> {
-	writer: W
+pub(crate) struct ArcaHeaderSerializer<W: Write> {
+	pub(crate) writer: W
 }
 
 impl<W: Write> Serializer for ArcaHeaderSerializer<W> {


### PR DESCRIPTION
# Related issue
Relates to #5 

# Description of changes
- Added `log` crate as dependency, activated by the feature `logging`
- Added some logging to existing routines via helper macros
- These helper macros expand to the actual `log` crate call when feature `logging` is activated and expand to {} (no-op) when deactivated, this avoids having to use feature guards (#[cfg(feature = "logging")]) on every log call
- Changed access modifiers of `crate::serde::serializer::{Self, ArcaHeaderSerializer}` to `pub(crate)`
- The logging feature has been separated into a different module called `features`
- Additionally, i added an unfinished function at `crate::arca` called `sync` as a method over the `Arca` struct, it will be used to sync any changes made during runtime to the file handle (and eventually to the filesystem)

# Closes issue
Closes #5 
